### PR TITLE
Multi image support

### DIFF
--- a/main.py
+++ b/main.py
@@ -312,9 +312,6 @@ async def on_message_edit(old: discord.Message, new: discord.Message) -> None:
     Sometimes embeds aren't ready when we see the message.
     In this case, we should get an on_message_edit once it is.
     """
-    # reset cache on message edit
-    # unlikely to reuse cache
-    fx_cache.clear()
     if new.author.bot:
         # ignore bots and self
         return

--- a/main.py
+++ b/main.py
@@ -130,10 +130,13 @@ async def unnag(message: discord.Message) -> None:
     """
     Remove the fxtwitter link
     """
-    print(
-        f"!! removing response to {message.id} in {message.channel} on {message.guild}"
-    )
     if message.id in nags:
+        guild_string = ""
+        if message.guild is not None:
+            guild_string = f"on {message.guild.id}"
+        print(
+            f"!! removing response to {message.id} in {message.channel.id}{guild_string}"
+        )
         await nags[message.id].delete()
 
 

--- a/main.py
+++ b/main.py
@@ -198,9 +198,10 @@ def should_nag(message: discord.Message) -> Optional[NagType]:
                     discord.ForumChannel,
                     discord.StageChannel,
                     discord.VoiceChannel,
+                    discord.Thread,
                 ),
             )
-            and channel.nsfw
+            and channel.is_nsfw()
         ):
             return NagType.FULL
         # nsfw in sfw channel, prevent embed

--- a/main.py
+++ b/main.py
@@ -279,9 +279,7 @@ def _is_video_tweet(embed: discord.Embed) -> bool:
     # native video embed now uses a thumbnail instead of broken video
     # URL begins with https://pbs.twimg.com/ext_tw_video_thumb/
     # or https://pbs.twimg.com/tweet_video_thumb/
-    contains_video_thumbnail = "ext_tw_video_thumb" in embed.image.url
-    contains_gif_thumbnail = "tweet_video_thumb" in embed.image.url
-    return contains_video_thumbnail or contains_gif_thumbnail
+    return "_video_thumb/" in embed.image.url
 
 
 def _has_sensitive_tweet(message: discord.Message) -> bool:

--- a/main.py
+++ b/main.py
@@ -159,9 +159,7 @@ async def unnag(message: discord.Message) -> None:
     Remove the fxtwitter link
     """
     if message.id in nags:
-        guild_string = ""
-        if message.guild is not None:
-            guild_string = f"on {message.guild.id}"
+        guild_string = f"on {message.guild.id}" if message.guild is not None else ""
         print(
             f"!! removing response to {message.id} in {message.channel.id}{guild_string}"
         )

--- a/main.py
+++ b/main.py
@@ -190,9 +190,18 @@ def should_nag(message: discord.Message) -> Optional[NagType]:
         if channel.type in (discord.ChannelType.private, discord.ChannelType.group):
             # always allow NSFW in (group) DMs
             return NagType.FULL
-        if hasattr(channel, "nsfw") and getattr(channel, "nsfw") is True:
-            # .nsfw seems to not exist on some channel types
-            # and discord.py type narrowing is limited
+        if (
+            isinstance(
+                channel,
+                (
+                    discord.TextChannel,
+                    discord.ForumChannel,
+                    discord.StageChannel,
+                    discord.VoiceChannel,
+                ),
+            )
+            and channel.nsfw
+        ):
             return NagType.FULL
         # nsfw in sfw channel, prevent embed
         print("Skipping NSFW embed in SFW channel")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,2 @@
-aiohttp==3.9.3
-aiosignal==1.3.1
-async-timeout==4.0.3
-attrs==23.2.0
-charset-normalizer==3.3.2
 discord.py==2.3.2
-frozenlist==1.4.1
-idna==3.6
-multidict==6.0.5
-yarl==1.9.4
+requests==2.31.0


### PR DESCRIPTION
Requires #2 to be merged first, and then this must be rebased before merging.

Closes #3.

Additional dependency on FxTwitter API, and as such also on the `requests` library.
Attempted to use the builtin `http` library but that ended up with too much logic dedicated to error handling.

In addition to the currently supported nags, additional nag types are now supported:
- Multi-image (bot only posts the mosaic)
- Videos and GIFs (bot only posts the video)
- Two image tweets (bot only posts the second image)